### PR TITLE
Update itinerary for June 21-24

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,20 +287,23 @@
                 <div class="space-y-4">
                     <div class="activity-item"><strong class="text-amber-600">Vormittag:</strong> Auschecken Hotel: Villa Fontaine Tokyo Hamamatsucho.</div>
                     <div class="activity-item"><strong class="text-amber-600">Nachmittag:</strong> Einchecken Hotel: Almont Hotel Kyoto.</div>
-                    <div class="activity-item" data-theme="kultur"><strong class="text-amber-600">Abend:</strong> Kinkaku-ji Goldener Pavillon &amp; Kiyomizu-dera Tempel Abends.</div>
+                    <div class="activity-item" data-theme="kultur"><strong class="text-amber-600">Abend:</strong> Kinkaku-ji Goldener Pavillon, Sennyū-ji Tempel &amp; Kiyomizu-dera Tempel.</div>
                 </div>` },
-            { day: 5, date: "22. Juni", location: "Kyoto", title: "Fushimi Inari & Arashiyama", themes: ['kultur'], preBooked: false, details: `
+            { day: 5, date: "22. Juni", location: "Kyoto", title: "Fushimi Inari & Kodaiji", themes: ['kultur'], preBooked: false, details: `
                 <div class="space-y-4">
                     <div class="activity-item" data-theme="kultur"><strong class="text-amber-600">Früh morgens:</strong> Fushimi Inari Taisha Schrein.</div>
-                    <div class="activity-item" data-theme="kultur"><strong class="text-amber-600">Vormittag:</strong> Arashiyama Bambuswald (Bamboo Grove).</div>
-                    <div class="activity-item"><strong class="text-amber-600">Rest des Tages:</strong> Freie Gestaltung in Kyoto.</div>
+                    <div class="activity-item" data-theme="kultur"><strong class="text-amber-600">Vormittag:</strong> Bamboo Forest of Kodaiji.</div>
+                    <div class="activity-item" data-theme="kultur"><strong class="text-amber-600">Nachmittag:</strong> Nishiki Market erkunden.</div>
                 </div>` },
-            { day: 6, date: "23. Juni", location: "Kyoto", title: "Freier Tag", themes: [], preBooked: false, details: `<p>Dieser Tag steht zur freien Verfügung in Kyoto.</p>` },
+            { day: 6, date: "23. Juni", location: "Kyoto", title: "Ausflug Nara & Arashiyama", themes: ['kultur'], preBooked: false, details: `
+                <div class="space-y-4">
+                    <div class="activity-item" data-theme="kultur"><strong class="text-amber-600">Ganztägig:</strong> Ausflug nach Nara – Tōdai-ji Tempel &amp; Bambus Wald Arashiyama.</div>
+                </div>` },
             { day: 7, date: "24. Juni", location: "Kyoto → Osaka", title: "Reise nach Osaka", themes: [], preBooked: false, details: `
                 <div class="space-y-4">
                     <div class="activity-item"><strong class="text-amber-600">Vormittag:</strong> Auschecken Hotel: Almont Hotel Kyoto.</div>
                     <div class="activity-item"><strong class="text-amber-600">Nachmittag:</strong> Einchecken Hotel: Smile Hotel Shinosaka.</div>
-                    <div class="activity-item"><strong class="text-amber-600">Abend:</strong> Freie Gestaltung in Osaka.</div>
+                    <div class="activity-item" data-theme="kultur"><strong class="text-amber-600">Abend:</strong> Burg Osaka (Osaka Castle), Tsutenkaku &amp; Dotonbori.</div>
                 </div>` },
             { day: 8, date: "25. Juni", location: "Osaka", title: "Universal Studios Japan", themes: ['anime'], preBooked: true, details: `
                 <div class="space-y-4">


### PR DESCRIPTION
## Summary
- revise days 4–7 in the interactive itinerary
- include Sennyū-ji on June 21
- adjust June 22 with Kodaiji and Nishiki Market
- add a day trip to Nara & Arashiyama on June 23
- list Osaka Castle, Tsutenkaku and Dotonbori on June 24

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684aa204ce0c832d913eb44a79d97009