### PR TITLE
Update itinerary activities

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,20 +287,25 @@
                 <div class="space-y-4">
                     <div class="activity-item"><strong class="text-amber-600">Vormittag:</strong> Auschecken Hotel: Villa Fontaine Tokyo Hamamatsucho.</div>
                     <div class="activity-item"><strong class="text-amber-600">Nachmittag:</strong> Einchecken Hotel: Almont Hotel Kyoto.</div>
-                    <div class="activity-item" data-theme="kultur"><strong class="text-amber-600">Abend:</strong> Kinkaku-ji Goldener Pavillon &amp; Kiyomizu-dera Tempel Abends.</div>
+                    <div class="activity-item" data-theme="kultur"><strong class="text-amber-600">Nachmittag:</strong> Kinkaku-ji (Goldener Pavillon) und Sennyū-ji Tempel.</div>
+                    <div class="activity-item" data-theme="kultur"><strong class="text-amber-600">Abend:</strong> Kiyomizu-dera Tempel.</div>
                 </div>` },
-            { day: 5, date: "22. Juni", location: "Kyoto", title: "Fushimi Inari & Arashiyama", themes: ['kultur'], preBooked: false, details: `
+            { day: 5, date: "22. Juni", location: "Kyoto", title: "Fushimi Inari & Kodaiji", themes: ['kultur'], preBooked: false, details: `
                 <div class="space-y-4">
                     <div class="activity-item" data-theme="kultur"><strong class="text-amber-600">Früh morgens:</strong> Fushimi Inari Taisha Schrein.</div>
-                    <div class="activity-item" data-theme="kultur"><strong class="text-amber-600">Vormittag:</strong> Arashiyama Bambuswald (Bamboo Grove).</div>
-                    <div class="activity-item"><strong class="text-amber-600">Rest des Tages:</strong> Freie Gestaltung in Kyoto.</div>
+                    <div class="activity-item" data-theme="kultur"><strong class="text-amber-600">Vormittag:</strong> Bamboo Forest of Kodaiji.</div>
+                    <div class="activity-item" data-theme="kultur"><strong class="text-amber-600">Nachmittag:</strong> Nishiki Market.</div>
                 </div>` },
-            { day: 6, date: "23. Juni", location: "Kyoto", title: "Freier Tag", themes: [], preBooked: false, details: `<p>Dieser Tag steht zur freien Verfügung in Kyoto.</p>` },
+            { day: 6, date: "23. Juni", location: "Kyoto", title: "Ausflug Nara & Arashiyama", themes: ['kultur'], preBooked: false, details: `
+                <div class="space-y-4">
+                    <div class="activity-item" data-theme="kultur"><strong class="text-amber-600">Vormittag:</strong> Ausflug nach Nara – Tōdai-ji Tempel.</div>
+                    <div class="activity-item" data-theme="kultur"><strong class="text-amber-600">Nachmittag:</strong> Bambuswald Arashiyama.</div>
+                </div>` },
             { day: 7, date: "24. Juni", location: "Kyoto → Osaka", title: "Reise nach Osaka", themes: [], preBooked: false, details: `
                 <div class="space-y-4">
                     <div class="activity-item"><strong class="text-amber-600">Vormittag:</strong> Auschecken Hotel: Almont Hotel Kyoto.</div>
                     <div class="activity-item"><strong class="text-amber-600">Nachmittag:</strong> Einchecken Hotel: Smile Hotel Shinosaka.</div>
-                    <div class="activity-item"><strong class="text-amber-600">Abend:</strong> Freie Gestaltung in Osaka.</div>
+                    <div class="activity-item"><strong class="text-amber-600">Abend:</strong> Burg Osaka (Osaka Castle), Tsutenkaku und Dotonbori erkunden.</div>
                 </div>` },
             { day: 8, date: "25. Juni", location: "Osaka", title: "Universal Studios Japan", themes: ['anime'], preBooked: true, details: `
                 <div class="space-y-4">
@@ -329,7 +334,11 @@
                 <div class="space-y-4">
                     <div class="activity-item" data-theme="anime technologie"><strong class="text-amber-600">Ganztägig:</strong> Ab zur Akihabara Station – Erkundung des Anime-/Elektro-Viertels.</div>
                 </div>` },
-            { day: 15, date: "2. Juli", location: "Tokio", title: "Freier Tag", themes: [], preBooked: false, details: `<p>Dieser Tag steht zur freien Verfügung in Tokio.</p>` },
+            { day: 15, date: "2. Juli", location: "Tokio", title: "Nakano & Harry Potter?", themes: ['anime'], preBooked: false, details: `
+                <div class="space-y-4">
+                    <div class="activity-item" data-theme="anime"><strong class="text-amber-600">Vormittag:</strong> Nakano Sun Mall und Nakano Broadway erkunden.</div>
+                    <div class="activity-item" data-theme="anime"><strong class="text-amber-600">Nachmittag (optional):</strong> The Making of Harry Potter - Warner Bros. Studio Tour Tokyo.</div>
+                </div>` },
             { day: 16, date: "3. Juli", location: "Tokio", title: "Auschecken", themes: [], preBooked: false, details: `
                 <div class="space-y-4">
                     <div class="activity-item"><strong class="text-amber-600">Ganztägig:</strong> Auschecken Hotel: Shinjuku Granbell Hotel.</div>


### PR DESCRIPTION
## Summary
- update Kyoto temple day with Sennyū-ji
- adjust Kyoto days for Kodaiji bamboo, Nara and Arashiyama
- add Osaka evening sightseeing
- include Nakano Broadway and optional Harry Potter tour in Tokyo

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684feebdb9a8832da41ab88836fc4a83